### PR TITLE
Ensure all necessary files gets copied.

### DIFF
--- a/scripts/ios/after_build.sh
+++ b/scripts/ios/after_build.sh
@@ -1,2 +1,2 @@
-rm -Rf www
+rm -rf www
 mv app www

--- a/scripts/ios/before_build.sh
+++ b/scripts/ios/before_build.sh
@@ -4,8 +4,5 @@ mkdir www
 mkdir www/jxcore
 echo "var thali = require('./thali.jx');" > www/jxcore/app.js
 mv app/jxcore/thali.jx www/jxcore
-cp app/* www
-cp -R app/js www
-cp -R app/img www
-cp -R app/css www
+rsync -a --exclude "/jxcore" app/ www
 rm app/jxcore/thali.jxp


### PR DESCRIPTION
Previously, the copy command copied only certain folders, which might have
excluded something.
